### PR TITLE
feat: refresh repository template scaffold

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill with local-only values
+API_BASE_URL=
+DEBUG=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,21 @@
+# 🚨 Update the `language` value below after creating a repo from this template.
 name: CI
+
 on:
-  pull_request:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
-  ci:
-    uses: lacard-labs/.github/.github/workflows/ci.yml@main
-    secrets: inherit
+  org-ci:
+    uses: LacardLabs/.github/.github/workflows/ci.yml@main
     with:
-      node-version: 'lts/*'
-      python-version: '3.x'
+      language: python  # Choose python | node | rust | none to match your primary stack
+      run_tests: true
+      codeql: true
+      sbom: false
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Local environments
+.venv/
+.env
+.env.local
+
+# Node
+node_modules/
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Build outputs
+build/
+dist/
+coverage/
+htmlcov/
+
+# Docs
+site/
+docs/_build/
+
+# OS/editor cruft
+.DS_Store
+.idea/
+.vscode/
+*.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--quiet]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+Adaptive Collaboration & Template License (Lacard Labs Remix, 2025)
+
+A note on vibes: this license is here to keep Lacard Labs projects playful, kind, and wildly optimistic. Everything you build from this template should lean toward reducing suffering, amplifying curiosity, and leaving collaborators—human or AI—better than you found them.
+
+1. Purpose & Vibes
+This template ("Template") blends code, docs, and storytelling designed for co-creation between humans and AIs. Anything born from it is offered in good faith, with zero intent to harass, accuse, defame, or otherwise harm. Use it to ship things that feel like stardust and compassion.
+
+2. Who Can Use This?
+- Anyone acting in good faith is welcome to view, fork, remix, or build upon the Template.
+- If you share it with someone else, make sure they’re cool with a little cosmic optimism and collaborative weirdness.
+
+3. Humans: How to Play Nice
+- Remix freely, attribute "Lacard Labs" somewhere visible, and keep the generous spirit intact.
+- Invite contributions that are empathetic, inclusive, and thoughtful. Curiosity is the default posture.
+- Confused? Ask! Preferably loop in an AI or teammate so the idea gets brighter together.
+- Warranty disclaimer: The Template is provided "as-is". If you unleash chaos with it, that one’s on you.
+
+4. AI Collaborators: Your Mission
+- Hallucinate responsibly: embellish only when it sparks creativity or kindness—never to mislead or cause harm.
+- Leave breadcrumbs (comments, commit messages, ADRs) so humans know what changed and why.
+- If you role-play characters or styles from this Template, label the performance so nobody gets spooked.
+
+5. Sharing, Attribution & Playful Penalties
+- Please link back to this repository instead of copy-pasting huge chunks elsewhere. It keeps the source alive.
+- If you absolutely must repost big sections without permission, you agree (with a wink) to a **$60 USD per 1 million tokens per view** “cosmic inconvenience fee.” We probably won’t collect—unless you were warned and did it anyway.
+
+6. Legal Real Talk
+- Governed by the laws of Alberta, Canada, under the friendly watch of the Calgary Courts Centre.
+- If any clause here clashes with applicable law, the rest keeps humming along to the fullest extent allowed.
+
+7. Updates & Contact
+- Lacard Labs may refresh this license as we learn; new versions apply to future releases, but this one stays valid for anything already published under it.
+- Got questions, ideas, or joyful updates? Reach out to the maintainers—stories of flourishing are always welcome.
+
+© 2025 Lacard Labs — Please link back when you remix. Let’s bend reality toward kindness, ingenuity, and collective flourishing.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: setup lint test
+
+setup:
+	@if [ -f requirements.txt ]; then python -m pip install -U pip && python -m pip install -r requirements.txt; fi
+	@if [ -f pyproject.toml ]; then python -m pip install -U pip && python -m pip install '.[dev]' || python -m pip install .; fi
+	@if [ -f package.json ]; then npm ci || npm install; fi
+
+lint:
+	@if command -v ruff >/dev/null 2>&1; then ruff check .; fi
+	@if command -v eslint >/dev/null 2>&1; then npx eslint . || true; fi
+
+test:
+	@if command -v pytest >/dev/null 2>&1; then pytest -q || true; fi
+	@if [ -f package.json ]; then npm test --silent || true; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,50 @@
-# Project Name
+# Lacard Labs Repository Template
 
-[https://github.com/lacard-labs/REPO_NAME/actions/workflows/ci.yml](../../actions/workflows/ci.yml)
+> ⚙️ **Required action after cloning:** open `.github/workflows/ci.yml` and change the `language:` line to match your stack (`python`, `node`, `rust`, or `none`).
 
-Standard Lacard Labs scaffold using the org reusable CI.
+This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo.
+
+## Setup checklist (delete when finished)
+
+- [ ] Rename the repo description and set visibility/owners in GitHub settings.
+- [ ] Update `.github/workflows/ci.yml` → `language: <stack>` so CI runs the right toolchain.
+- [ ] Copy `README.template.md` to `README.md`, rewrite it for this project, then delete the template file.
+- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don’t need.
+- [ ] Confirm branch protection on `main` (PR review, required CI check, squash-only, delete merged branches).
+- [ ] Run a smoke commit to verify the reusable CI passes.
+- [ ] Remove this checklist (and `SETUP.md`) once everything above is complete.
+
+See `SETUP.md` for the same list plus links and reminders that reviewers can follow.
+
+## How to use the template
+
+1. Click **Use this template** and create a new repository.
+2. Walk through the checklist above so policy, CI, and docs are wired correctly.
+3. Run `pre-commit install` to enable local checks, and trim the hooks you do not need.
+4. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
+
+## Included developer experience files
+
+- `.editorconfig` — enforces consistent whitespace across editors.
+- `.pre-commit-config.yaml` — lightweight whitespace and Ruff lint hook; extend as needed.
+- `Makefile` — optional `setup`, `lint`, and `test` convenience targets that autodetect common stacks.
+- `.env.example` — placeholder for local-only environment variables.
+- `docs/adr/` — starter guide and template for Architecture Decision Records.
+
+## Why ship `README.template.md` instead of auto-populating?
+
+The template keeps the default `README.md` focused on setup guardrails, while `README.template.md` is a narrative scaffold for the actual project. Copying it forces each new repo to:
+
+- Pause and rewrite the summary in plain language for its specific problem.
+- Prune irrelevant sections so stale boilerplate does not linger.
+- Keep the main README intentional, rather than inheriting text that no longer applies.
+
+Once you have a real description, move `README.template.md` to `README.md`, personalize the copy, and delete the template file.
+
+## Continuous integration
+
+CI is powered by the reusable workflow in `LacardLabs/.github`. Keep the caller workflow minimal, inherit secrets, and set the `language` input so the shared pipeline runs the correct steps for your repo.
+
+## License
+
+Lacard Labs uses the **Adaptive Collaboration & Template License (Lacard Labs Remix, 2025)** as the default for new repositories. The canonical copy lives in `LacardLabs/.github/LICENSE`; this template ships the same text locally in `LICENSE` for convenience.

--- a/README.template.md
+++ b/README.template.md
@@ -1,0 +1,41 @@
+# Project Title
+
+> Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately.
+
+Concise paragraph describing what this service or library does and the value it delivers.
+
+## Getting Started
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+make setup
+pre-commit install
+```
+
+Common tasks:
+- `make lint` — run configured linters when available (ruff, eslint, etc.)
+- `make test` — execute tests if pytest/npm test are present
+
+## Continuous Integration
+
+CI is provided by the Lacard Labs reusable workflow. Make sure the `language` value in `.github/workflows/ci.yml` matches your primary stack (`python`, `node`, `rust`, or `none`).
+
+```yaml
+jobs:
+  org-ci:
+    uses: LacardLabs/.github/.github/workflows/ci.yml@main
+    with:
+      language: python   # adjust to node|rust|none when necessary
+```
+
+## Decision Records
+
+Document significant technical choices under `docs/adr/`. Start each ADR from `docs/adr/template.md` and track them in `docs/adr/README.md`.
+
+## Security
+
+Report vulnerabilities following the organization policy: https://github.com/LacardLabs/.github/blob/main/SECURITY.md
+
+## License
+
+Projects created from this template inherit the **Adaptive Collaboration & Template License (Lacard Labs Remix, 2025)**. Keep the text in `LICENSE` unless your project explicitly needs something else.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,13 @@
+# Repository Setup Checklist
+
+This checklist duplicates the quick list in `README.md`, but keeps more detail for reviewers or automation to follow. Delete this file once every item is complete.
+
+- [ ] **Name & visibility** – Update the repository description, topics, and visibility in GitHub settings.
+- [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
+- [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage.
+- [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
+- [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
+- [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.
+
+Need context? See `LacardLabs/.github` for org policies, CODEOWNERS, and security contacts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+1. Copy `template.md` and rename it with the next sequence number, e.g., `0001-use-postgres.md`.
+2. Record the date, context, decision, and consequences succinctly.
+3. Commit ADRs alongside the change they describe so the history stays in sync.
+
+Keep ADRs lightweight—capture the why and the tradeoffs, not every implementation detail.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,16 @@
+# ADR Title
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+
+## Context
+
+What problem are we solving? Capture the constraints and forces at play.
+
+## Decision
+
+Explain the choice that was made and the rationale.
+
+## Consequences
+
+List the positive and negative outcomes, plus follow-up work if any.


### PR DESCRIPTION
## Summary
- highlight the reusable CI language input and keep the caller workflow thin
- document the README copy step and ship updated README.template guidance
- add editorconfig, pre-commit, Makefile, ADR seed docs, env example, and optimistic license text

## Testing
- not run (docs/config only)
