### PR TITLE
Clarify template setup guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root contains shared scaffolding only: `README.template.md`, `.pre-commit-config.yaml`, `Makefile` (optional), `docs/adr/`.
+- Keep source code under a language-appropriate directory (e.g., `src/`, `app/`) and mirror tests under `tests/` or `<lang>_tests/`.
+- Store local assets in `docs/` or `assets/` so template files stay uncluttered.
+- Delete unused scaffold files early to keep the starter lean.
+
+## Build, Test, and Development Commands
+- Clone after creating the repo with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>`.
+- Run `pre-commit install` once; hooks will lint and auto-fix whitespace on every commit.
+- Prefer language-native tooling (`npm test`, `pytest`, `cargo test`). Only enable Make targets if your stack already relies on `make`.
+- Use `pwd` before committing to confirm you are under `~/GitHub/LacardLabs/<repo>`.
+
+## Coding Style & Naming Conventions
+- Follow the language community standard (PEP 8, ESLint defaults, Rustfmt). Enable formatters via pre-commit when possible.
+- Use snake_case for files in Python, kebab-case for JavaScript packages, and PascalCase for exported types.
+- Keep indentation at 4 spaces unless a framework enforces otherwise; `.editorconfig` enforces defaults.
+- Document new directories with a short README when intent is not obvious.
+
+## Testing Guidelines
+- Mirror test file names to the implementation (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
+- Keep fast unit tests in CI; mark slower integration suites with conventional skips if they need toggles.
+- Target >80% coverage when the stack provides tooling; explain lower coverage in the PR summary.
+- Run the full test suite locally before requesting review.
+
+## Commit & Pull Request Guidelines
+- Write commits in the narrated voice outlined in `.github/CONTRIBUTING.md`; lead with the why before the what.
+- Reference the driving issue in the first line when possible (`feat: align auth scopes (#123)`).
+- Keep PRs narrowly scoped; include screenshots or terminal captures when behaviour changes.
+- Confirm CI passes and note any required follow-ups or toggles under a "Next steps" heading in the PR body.
+
+## Agent-Specific Notes
+- Automations and scripts assume repositories live under `~/GitHub/LacardLabs/<repo>`.
+- Prefer idempotent commands; call tooling with explicit paths so agents can re-run safely.
+- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers in sync.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,36 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Root contains shared scaffolding only: `README.template.md`, `.pre-commit-config.yaml`, `Makefile` (optional), `docs/adr/`.
-- Keep source code under a language-appropriate directory (e.g., `src/`, `app/`) and mirror tests under `tests/` or `<lang>_tests/`.
-- Store local assets in `docs/` or `assets/` so template files stay uncluttered.
-- Delete unused scaffold files early to keep the starter lean.
+- Keep the root slim: shared scaffolding only (`README.template.md`, `.pre-commit-config.yaml`, optional `Makefile`, `docs/adr/`).
+- Put application code under the stack's conventional directory (`src/`, `app/`, etc.) and mirror tests under `tests/` or `<lang>_tests/`; store docs and assets in `docs/` or `assets/`.
 
 ## Build, Test, and Development Commands
-- Clone after creating the repo with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>`.
-- Run `pre-commit install` once; hooks will lint and auto-fix whitespace on every commit.
-- Prefer language-native tooling (`npm test`, `pytest`, `cargo test`). Only enable Make targets if your stack already relies on `make`.
-- Use `pwd` before committing to confirm you are under `~/GitHub/LacardLabs/<repo>`.
+- Create the repo from the template, then clone with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>`; run `pwd` to confirm the path before committing.
+- Run `pre-commit install` once; hooks auto-fix whitespace and run Ruff before every commit.
+- Use language-native tooling for build/test (`npm test`, `pytest`, `cargo test`). Only opt into `Makefile` targets if your stack already depends on `make`.
 
 ## Coding Style & Naming Conventions
-- Follow the language community standard (PEP 8, ESLint defaults, Rustfmt). Enable formatters via pre-commit when possible.
-- Use snake_case for files in Python, kebab-case for JavaScript packages, and PascalCase for exported types.
-- Keep indentation at 4 spaces unless a framework enforces otherwise; `.editorconfig` enforces defaults.
-- Document new directories with a short README when intent is not obvious.
+- Rely on formatter defaults (PEP 8, ESLint, Rustfmt); `.editorconfig` keeps indentation at 4 spaces unless the framework overrides it.
+- Use snake_case for Python modules, kebab-case for JavaScript packages, PascalCase for exported types. Document exceptions inline when necessary.
 
 ## Testing Guidelines
-- Mirror test file names to the implementation (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
-- Keep fast unit tests in CI; mark slower integration suites with conventional skips if they need toggles.
-- Target >80% coverage when the stack provides tooling; explain lower coverage in the PR summary.
+- Match test file names to their targets (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
+- Keep unit tests fast enough for CI; mark slow suites with conventional skips or flags.
+- Aim for about 80% coverage when tooling supports it and explain gaps in the PR.
 - Run the full test suite locally before requesting review.
 
 ## Commit & Pull Request Guidelines
-- Write commits in the narrated voice outlined in `.github/CONTRIBUTING.md`; lead with the why before the what.
-- Reference the driving issue in the first line when possible (`feat: align auth scopes (#123)`).
-- Keep PRs narrowly scoped; include screenshots or terminal captures when behaviour changes.
-- Confirm CI passes and note any required follow-ups or toggles under a "Next steps" heading in the PR body.
+- Follow the narrated voice from `.github/CONTRIBUTING.md`: lead with the why, then the what and next steps.
+- Reference the driving issue in commit subject lines when available (`feat: align auth scopes (#123)`).
+- Keep PRs focused; include screenshots or terminal captures when behaviour changes.
+- Ensure CI is green and document any toggles or follow-up tasks under "Next steps" in the PR body.
+
+## Architecture Decision Records (ADRs)
+- Snapshot significant architecture choices under `docs/adr/`; copy `template.md` to the next `000X-title.md` file before editing.
+- Write concise context, decision, and consequence sections; update the status from `Proposed` to `Accepted`, `Rejected`, or `Superseded` once merged.
+- Link supporting issues, diagrams, or PRs in the ADR and reference the record in your pull request narrative. Leave superseded ADRs in place with a note to the successor.
 
 ## Agent-Specific Notes
 - Automations and scripts assume repositories live under `~/GitHub/LacardLabs/<repo>`.
-- Prefer idempotent commands; call tooling with explicit paths so agents can re-run safely.
-- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers in sync.
+- Prefer idempotent commands and pass explicit paths so agents can re-run safely.
+- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers aligned.

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -22,6 +22,11 @@
 - Restate your team's expectations for commit messages, PR structure, and required artifacts (screenshots, logs, etc.).
 - Link to any additional docs (CONTRIBUTING, architecture notes) reviewers should read before approving.
 
+## Architecture Decision Records (ADRs)
+- Explain when your team expects a new ADR versus updating an existing one.
+- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.).
+- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable.
+
 ## Agent-Specific Notes
 - Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).
 - Flag common pitfalls, reset procedures, or environment constraints that agents should surface in PRs.

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -1,0 +1,27 @@
+# Repository Guidelines
+
+> Copy this file to `AGENTS.md` and tailor each section for your project. Keep explanations concise (200–400 words) and specific to your repo.
+
+## Project Structure & Module Organization
+- Summarize where core source, tests, and assets reside once your project scaffolding is in place.
+- Note any directories that downstream agents should avoid or clean up after bootstrapping.
+
+## Build, Test, and Development Commands
+- Document the commands contributors should run after cloning (include `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` if you keep the default path assumption).
+- List the canonical build, lint, and test commands, calling out any optional tooling like `make`.
+
+## Coding Style & Naming Conventions
+- Record formatting standards (indentation, casing, formatter tools) that apply to your stack.
+- Mention naming patterns for files, packages, and exported symbols so agents can create files confidently.
+
+## Testing Guidelines
+- Describe the testing frameworks in use and how to execute the suites locally.
+- Include coverage expectations, file naming conventions, and guidance for slow or optional tests.
+
+## Commit & Pull Request Guidelines
+- Restate your team's expectations for commit messages, PR structure, and required artifacts (screenshots, logs, etc.).
+- Link to any additional docs (CONTRIBUTING, architecture notes) reviewers should read before approving.
+
+## Agent-Specific Notes
+- Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).
+- Flag common pitfalls, reset procedures, or environment constraints that agents should surface in PRs.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Lacard Labs Repository Template
 
-> ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
+> ⚙️ After bootstrapping with **Use this template**, create the repo on GitHub, then run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>` before editing. Update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
-This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo locally.
+This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo to `~/GitHub/LacardLabs/<repo>`.
 
 ## Setup checklist (delete when finished)
 
 - [ ] In **Settings → General**, update the repo description, confirm visibility, and assign the owning team.
+- [ ] Clone the repo locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and verify `pwd` resolves to that path.
 - [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
 - [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
 - [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don't need.
@@ -19,10 +20,10 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 ## How to use the template
 
 1. Click **Use this template** to create the new repository under the Lacard Labs org.
-2. Clone it locally before editing; all commands below assume you are inside the repo directory.
+2. Clone it locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` before editing; all commands below assume you are inside that directory.
 3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
 4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
-5. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
+5. Run `pwd` or `ls` to sanity-check that you are under `~/GitHub/LacardLabs/<repo>` before committing. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
 
 ## Included developer experience files
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
 # Lacard Labs Repository Template
 
-> ⚙️ **Required action after cloning:** open `.github/workflows/ci.yml` and change the `language:` line to match your stack (`python`, `node`, `rust`, or `none`).
+> ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
 This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo.
 
 ## Setup checklist (delete when finished)
 
-- [ ] Rename the repo description and set visibility/owners in GitHub settings.
-- [ ] Update `.github/workflows/ci.yml` → `language: <stack>` so CI runs the right toolchain.
-- [ ] Copy `README.template.md` to `README.md`, rewrite it for this project, then delete the template file.
-- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don’t need.
-- [ ] Confirm branch protection on `main` (PR review, required CI check, squash-only, delete merged branches).
-- [ ] Run a smoke commit to verify the reusable CI passes.
+- [ ] In **Settings → General**, update the repo description, confirm visibility, and assign the owning team.
+- [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
+- [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
+- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don't need.
+- [ ] Confirm `main` branch protection (PR review, required CI check, squash-only merges, delete merged branches) matches org policy.
+- [ ] Push a quick "smoke" commit to verify the reusable CI passes end to end.
 - [ ] Remove this checklist (and `SETUP.md`) once everything above is complete.
 
 See `SETUP.md` for the same list plus links and reminders that reviewers can follow.
 
 ## How to use the template
 
-1. Click **Use this template** and create a new repository.
-2. Walk through the checklist above so policy, CI, and docs are wired correctly.
-3. Run `pre-commit install` to enable local checks, and trim the hooks you do not need.
-4. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
+1. Click **Use this template** to create the new repository under the Lacard Labs org.
+2. Clone it locally before editing; all commands below assume you are inside the repo directory.
+3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
+4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
+5. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
 
 ## Included developer experience files
 
 - `.editorconfig` — enforces consistent whitespace across editors.
-- `.pre-commit-config.yaml` — lightweight whitespace and Ruff lint hook; extend as needed.
+- `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
 - `Makefile` — optional `setup`, `lint`, and `test` convenience targets that autodetect common stacks.
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.
 
+## Architecture Decision Records
+
+- Create a new ADR whenever you commit to a meaningful architectural choice (data store, deployment model, auth strategy, cross-service contracts).
+- Copy `docs/adr/template.md` to the next sequence number (e.g., `cp docs/adr/template.md docs/adr/0003-adopt-openapi.md`), update the front matter, and capture context, decision, and consequences.
+- Keep the status field accurate (`Proposed` → `Accepted`/`Rejected`/`Superseded`) and link to the tracking issue or PR in the decision section so readers can follow the history.
+- Commit ADRs alongside the implementation change and mention the record in your PR under the "Develop" or "Docs" callout so reviewers see the rationale.
+
 ## Why ship `README.template.md` instead of auto-populating?
 
 The template keeps the default `README.md` focused on setup guardrails, while `README.template.md` is a narrative scaffold for the actual project. Copying it forces each new repo to:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
-This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo.
+This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo locally.
 
 ## Setup checklist (delete when finished)
 
@@ -22,13 +22,13 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 2. Clone it locally before editing; all commands below assume you are inside the repo directory.
 3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
 4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
-5. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
+5. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
 
 ## Included developer experience files
 
 - `.editorconfig` — enforces consistent whitespace across editors.
 - `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
-- `Makefile` — optional `setup`, `lint`, and `test` convenience targets that autodetect common stacks.
+- `Makefile` — optional `setup`, `lint`, and `test` convenience targets. Delete it if you prefer not to depend on `make` yet.
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.
 

--- a/README.template.md
+++ b/README.template.md
@@ -1,20 +1,26 @@
 # Project Title
 
-> Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately.
+> Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately. After
+> creating the repo from the template, run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd` into that
+> directory before editing so local scripts and automations resolve correctly.
 
 Concise paragraph describing what this service or library does and the value it delivers.
 
 ## Getting Started
 
+Replace the commands below with the canonical workflow for your stack. The template ships a `Makefile` for convenience, but it
+is optional—drop the target examples if your team prefers direct tooling invocations.
+
 ```bash
 python -m venv .venv && source .venv/bin/activate
-make setup
+pip install -r requirements.txt  # or the equivalent for your ecosystem
 pre-commit install
 ```
 
 Common tasks:
-- `make lint` — run configured linters when available (ruff, eslint, etc.)
-- `make test` — execute tests if pytest/npm test are present
+- `make setup` — bootstrap dependencies when you keep the provided Makefile around
+- `make lint` — run configured linters (ruff, eslint, etc.) if the Makefile fits your workflow
+- `make test` — execute tests when your project wires them into the Makefile
 
 ## Continuous Integration
 

--- a/README.template.md
+++ b/README.template.md
@@ -5,7 +5,16 @@
 > 1. Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>`.
 > 2. `cd ~/GitHub/LacardLabs/<repo>` before editing so local scripts and automations resolve correctly.
 > 3. Verify `pwd` outputs `~/GitHub/LacardLabs/<repo>` and `git remote -v` points at `git@github.com:LacardLabs/<repo>.git`.
-> 4. Note any prerequisites—language runtimes, package managers, container images—that new contributors must install.
+> 4. Capture those checks (copy/paste or screenshot) in the README so future contributors can sanity check their own setup.
+> 5. Note any prerequisites—language runtimes, package managers, container images—that new contributors must install.
+
+> 📍 **Example setup transcript**
+> ```bash
+> gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>
+> cd ~/GitHub/LacardLabs/<repo>
+> pwd                 # should resolve to ~/GitHub/LacardLabs/<repo>
+> git remote -v       # should list git@github.com:LacardLabs/<repo>.git
+> ```
 
 Concise paragraph describing what this service or library does and the value it delivers.
 

--- a/README.template.md
+++ b/README.template.md
@@ -2,16 +2,19 @@
 
 > Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately. After
 > creating the repo from the template, run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd` into that
-> directory before editing so local scripts and automations resolve correctly. Run `pwd` to confirm the repo lives at
-> `~/GitHub/LacardLabs/<repo>` and wire up any language-specific prerequisites before you commit.
+> directory before editing so local scripts and automations resolve correctly. Run `pwd` (it should resolve to
+> `~/GitHub/LacardLabs/<repo>`) before committing and note any prerequisites—language runtimes, package managers, container
+> images—that new contributors must install.
 
 Concise paragraph describing what this service or library does and the value it delivers.
 
 ## Getting Started
 
-Replace the commands below with the canonical workflow for your stack. The template ships a `Makefile` for convenience, but it
-is optional—drop the target examples if your team prefers direct tooling invocations. Call out which local smoke tests reviewers
-should run (`npm test`, `pytest`, etc.) so contributors can sanity check before opening a PR.
+Replace the commands below with the canonical workflow for your stack and add a short note about how you verified the repo path
+(`pwd` output, `ls` screenshot, etc.). The template ships a `Makefile` for convenience, but it is optional—drop the target
+examples if your team prefers direct tooling invocations. Call out which local smoke tests reviewers should run (`npm test`,
+`pytest`, etc.) so contributors can sanity check before opening a PR. If you expect extra setup (database migrations, container
+images, seed data), document those steps alongside the commands.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -19,11 +22,13 @@ pip install -r requirements.txt  # or the equivalent for your ecosystem
 pre-commit install
 ```
 
-Common tasks:
+Common tasks (replace or delete bullets so they reflect the tools you actually keep):
 - `make setup` — bootstrap dependencies when you keep the provided Makefile around
 - `make lint` — run configured linters (ruff, eslint, etc.) if the Makefile fits your workflow
 - `make test` — execute tests when your project wires them into the Makefile
 - `npm test` / `pytest` / `cargo test` — prefer direct tooling commands when that is the clearer contract for your stack
+- `npm run lint` / `poetry run pytest` / `<custom command>` — add direct invocations when the Makefile is removed or does not
+  cover the task
 
 ## Continuous Integration
 

--- a/README.template.md
+++ b/README.template.md
@@ -2,14 +2,16 @@
 
 > Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately. After
 > creating the repo from the template, run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd` into that
-> directory before editing so local scripts and automations resolve correctly.
+> directory before editing so local scripts and automations resolve correctly. Run `pwd` to confirm the repo lives at
+> `~/GitHub/LacardLabs/<repo>` and wire up any language-specific prerequisites before you commit.
 
 Concise paragraph describing what this service or library does and the value it delivers.
 
 ## Getting Started
 
 Replace the commands below with the canonical workflow for your stack. The template ships a `Makefile` for convenience, but it
-is optional—drop the target examples if your team prefers direct tooling invocations.
+is optional—drop the target examples if your team prefers direct tooling invocations. Call out which local smoke tests reviewers
+should run (`npm test`, `pytest`, etc.) so contributors can sanity check before opening a PR.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -21,6 +23,7 @@ Common tasks:
 - `make setup` — bootstrap dependencies when you keep the provided Makefile around
 - `make lint` — run configured linters (ruff, eslint, etc.) if the Makefile fits your workflow
 - `make test` — execute tests when your project wires them into the Makefile
+- `npm test` / `pytest` / `cargo test` — prefer direct tooling commands when that is the clearer contract for your stack
 
 ## Continuous Integration
 

--- a/README.template.md
+++ b/README.template.md
@@ -1,20 +1,21 @@
 # Project Title
 
 > Copy this file to `README.md`, rename the project, and rewrite the sections so they describe your service accurately. After
-> creating the repo from the template, run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd` into that
-> directory before editing so local scripts and automations resolve correctly. Run `pwd` (it should resolve to
-> `~/GitHub/LacardLabs/<repo>`) before committing and note any prerequisites—language runtimes, package managers, container
-> images—that new contributors must install.
+> creating the repo from the template:
+> 1. Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>`.
+> 2. `cd ~/GitHub/LacardLabs/<repo>` before editing so local scripts and automations resolve correctly.
+> 3. Verify `pwd` outputs `~/GitHub/LacardLabs/<repo>` and `git remote -v` points at `git@github.com:LacardLabs/<repo>.git`.
+> 4. Note any prerequisites—language runtimes, package managers, container images—that new contributors must install.
 
 Concise paragraph describing what this service or library does and the value it delivers.
 
 ## Getting Started
 
-Replace the commands below with the canonical workflow for your stack and add a short note about how you verified the repo path
-(`pwd` output, `ls` screenshot, etc.). The template ships a `Makefile` for convenience, but it is optional—drop the target
-examples if your team prefers direct tooling invocations. Call out which local smoke tests reviewers should run (`npm test`,
-`pytest`, etc.) so contributors can sanity check before opening a PR. If you expect extra setup (database migrations, container
-images, seed data), document those steps alongside the commands.
+Replace the commands below with the canonical workflow for your stack and add a short note (screenshot, `pwd` capture, or
+terminal snippet) that confirms the repo lives under `~/GitHub/LacardLabs/<repo>`. The template ships a `Makefile` for
+convenience, but it is optional—drop or rewrite the target examples if your team prefers direct tooling invocations. Call out
+which local smoke tests reviewers should run (`npm test`, `pytest`, etc.) so contributors can sanity check before opening a PR.
+If you expect extra setup (database migrations, container images, seed data), document those steps alongside the commands.
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -22,7 +23,7 @@ pip install -r requirements.txt  # or the equivalent for your ecosystem
 pre-commit install
 ```
 
-Common tasks (replace or delete bullets so they reflect the tools you actually keep):
+Common tasks (edit, add, or delete bullets so they match the tooling you actually rely on):
 - `make setup` — bootstrap dependencies when you keep the provided Makefile around
 - `make lint` — run configured linters (ruff, eslint, etc.) if the Makefile fits your workflow
 - `make test` — execute tests when your project wires them into the Makefile

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,11 +1,12 @@
 # Repository Setup Checklist
 
-This checklist duplicates the quick list in `README.md`, but keeps more detail for reviewers or automation to follow. Delete this file once every item is complete.
+This checklist duplicates the quick list in `README.md`, but keeps more detail for reviewers or automation to follow. Delete this file once every item is complete. All steps assume the repository was created from this template on GitHub and cloned locally under `~/GitHub/LacardLabs/<repo>`.
 
 - [ ] **Name & visibility** – Update the repository description, topics, and visibility in GitHub settings.
+- [ ] **Clone path** – Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and confirm `pwd` resolves to `~/GitHub/LacardLabs/<repo>` before making local edits.
 - [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
 - [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
-- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage. Remove the `Makefile` if your service won't adopt `make` yet.
 - [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
 - [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
 - [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,24 @@
 # Architecture Decision Records
 
-1. Copy `template.md` and rename it with the next sequence number, e.g., `0001-use-postgres.md`.
-2. Record the date, context, decision, and consequences succinctly.
-3. Commit ADRs alongside the change they describe so the history stays in sync.
+ADRs capture the narrative behind major technical choices so future contributors understand the why, not just the code diff. Use them when you:
 
-Keep ADRs lightweight—capture the why and the tradeoffs, not every implementation detail.
+- Introduce a new system boundary, integration, or deployment strategy.
+- Replace a core dependency (database, queue, framework) or change a critical design constraint.
+- Approve an experiment that alters reliability, scalability, or security characteristics.
+
+## How to create an ADR
+
+1. Identify the next sequence number in this directory (`ls docs/adr`); format it as four digits (`0001-...`).
+2. Copy the template: `cp docs/adr/template.md docs/adr/000X-short-title.md` and update the title to match the change.
+3. Fill out **Context**, **Decision**, and **Consequences** in 2–4 tight paragraphs each. Reference linked issues, diagrams, or RFCs inline.
+4. Set `Status` to `Proposed` while the change is under review. Update it to `Accepted`, `Rejected`, or `Superseded` once the PR lands.
+5. Commit the ADR alongside the implementation code so reviewers can evaluate intent and execution together.
+
+## Maintaining ADRs
+
+- Add a short summary or index entry to this README if the list grows beyond what `ls` can convey.
+- When a decision is replaced, leave the original ADR intact and add a "Superseded by" note pointing to the new record.
+- Keep language plain and action-oriented; these documents should answer "what should we keep doing or avoid?" for future teammates.
+- Link the ADR in your pull request under the Docs/Develop section so downstream readers can find it quickly.
+
+For additional background, see [Documenting architecture decisions](https://adr.github.io/).

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,7 +1,8 @@
 # ADR Title
 
-- Status: Proposed
+- Status: Proposed (Accepted | Rejected | Superseded)
 - Date: YYYY-MM-DD
+- Tags: optional-keywords
 
 ## Context
 
@@ -14,3 +15,7 @@ Explain the choice that was made and the rationale.
 ## Consequences
 
 List the positive and negative outcomes, plus follow-up work if any.
+
+## Links
+
+Reference related issues, pull requests, diagrams, or external docs that informed the decision.


### PR DESCRIPTION
## Summary
- emphasize GitHub-first workflow with canonical gh clone path and local sanity checks
- clarify that make/Makefile are optional tooling rather than default
- expand ADR documentation and templates so decisions stay discoverable
- add agent contributor guide (AGENTS.md) plus template for downstream repos

