### PR TITLE
docs: document ADR directory structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@
 - Ensure CI is green and document any toggles or follow-up tasks under "Next steps" in the PR body.
 
 ## Architecture Decision Records (ADRs)
-- Snapshot significant architecture choices under `docs/adr/`; copy `template.md` to the next `000X-title.md` file before editing.
-- Write concise context, decision, and consequence sections; update the status from `Proposed` to `Accepted`, `Rejected`, or `Superseded` once merged.
-- Link supporting issues, diagrams, or PRs in the ADR and reference the record in your pull request narrative. Leave superseded ADRs in place with a note to the successor.
+- Snapshot significant architecture choices under `docs/adr/`; copy `template.md` to the next `000X-title.md` file before editing and keep live ADRs at the top level.
+- Write concise context, decision, and consequence sections; update the status from `Proposed` to `Accepted`, `Rejected`, or `Superseded` once merged. Store heavy assets in `docs/adr/assets/<adr-number>/` and move superseded records into `docs/adr/archive/` after linking to the replacement.
+- Link supporting issues, diagrams, or PRs in the ADR and reference the record in your pull request narrative. Use `docs/adr/examples/0001-adopt-adr-process.md` as the baseline format, deleting `examples/` once the team has its own records.
 
 ## Agent-Specific Notes
 - Automations and scripts assume repositories live under `~/GitHub/LacardLabs/<repo>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root contains shared scaffolding only: `README.template.md`, `.pre-commit-config.yaml`, `Makefile` (optional), `docs/adr/`.
+- Keep source code under a language-appropriate directory (e.g., `src/`, `app/`) and mirror tests under `tests/` or `<lang>_tests/`.
+- Store local assets in `docs/` or `assets/` so template files stay uncluttered.
+- Delete unused scaffold files early to keep the starter lean.
+
+## Build, Test, and Development Commands
+- Clone after creating the repo with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>`.
+- Run `pre-commit install` once; hooks will lint and auto-fix whitespace on every commit.
+- Prefer language-native tooling (`npm test`, `pytest`, `cargo test`). Only enable Make targets if your stack already relies on `make`.
+- Use `pwd` before committing to confirm you are under `~/GitHub/LacardLabs/<repo>`.
+
+## Coding Style & Naming Conventions
+- Follow the language community standard (PEP 8, ESLint defaults, Rustfmt). Enable formatters via pre-commit when possible.
+- Use snake_case for files in Python, kebab-case for JavaScript packages, and PascalCase for exported types.
+- Keep indentation at 4 spaces unless a framework enforces otherwise; `.editorconfig` enforces defaults.
+- Document new directories with a short README when intent is not obvious.
+
+## Testing Guidelines
+- Mirror test file names to the implementation (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
+- Keep fast unit tests in CI; mark slower integration suites with conventional skips if they need toggles.
+- Target >80% coverage when the stack provides tooling; explain lower coverage in the PR summary.
+- Run the full test suite locally before requesting review.
+
+## Commit & Pull Request Guidelines
+- Write commits in the narrated voice outlined in `.github/CONTRIBUTING.md`; lead with the why before the what.
+- Reference the driving issue in the first line when possible (`feat: align auth scopes (#123)`).
+- Keep PRs narrowly scoped; include screenshots or terminal captures when behaviour changes.
+- Confirm CI passes and note any required follow-ups or toggles under a "Next steps" heading in the PR body.
+
+## Agent-Specific Notes
+- Automations and scripts assume repositories live under `~/GitHub/LacardLabs/<repo>`.
+- Prefer idempotent commands; call tooling with explicit paths so agents can re-run safely.
+- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers in sync.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,36 +1,36 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Root contains shared scaffolding only: `README.template.md`, `.pre-commit-config.yaml`, `Makefile` (optional), `docs/adr/`.
-- Keep source code under a language-appropriate directory (e.g., `src/`, `app/`) and mirror tests under `tests/` or `<lang>_tests/`.
-- Store local assets in `docs/` or `assets/` so template files stay uncluttered.
-- Delete unused scaffold files early to keep the starter lean.
+- Keep the root slim: shared scaffolding only (`README.template.md`, `.pre-commit-config.yaml`, optional `Makefile`, `docs/adr/`).
+- Put application code under the stack's conventional directory (`src/`, `app/`, etc.) and mirror tests under `tests/` or `<lang>_tests/`; store docs and assets in `docs/` or `assets/`.
 
 ## Build, Test, and Development Commands
-- Clone after creating the repo with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>`.
-- Run `pre-commit install` once; hooks will lint and auto-fix whitespace on every commit.
-- Prefer language-native tooling (`npm test`, `pytest`, `cargo test`). Only enable Make targets if your stack already relies on `make`.
-- Use `pwd` before committing to confirm you are under `~/GitHub/LacardLabs/<repo>`.
+- Create the repo from the template, then clone with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>`; run `pwd` to confirm the path before committing.
+- Run `pre-commit install` once; hooks auto-fix whitespace and run Ruff before every commit.
+- Use language-native tooling for build/test (`npm test`, `pytest`, `cargo test`). Only opt into `Makefile` targets if your stack already depends on `make`.
 
 ## Coding Style & Naming Conventions
-- Follow the language community standard (PEP 8, ESLint defaults, Rustfmt). Enable formatters via pre-commit when possible.
-- Use snake_case for files in Python, kebab-case for JavaScript packages, and PascalCase for exported types.
-- Keep indentation at 4 spaces unless a framework enforces otherwise; `.editorconfig` enforces defaults.
-- Document new directories with a short README when intent is not obvious.
+- Rely on formatter defaults (PEP 8, ESLint, Rustfmt); `.editorconfig` keeps indentation at 4 spaces unless the framework overrides it.
+- Use snake_case for Python modules, kebab-case for JavaScript packages, PascalCase for exported types. Document exceptions inline when necessary.
 
 ## Testing Guidelines
-- Mirror test file names to the implementation (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
-- Keep fast unit tests in CI; mark slower integration suites with conventional skips if they need toggles.
-- Target >80% coverage when the stack provides tooling; explain lower coverage in the PR summary.
+- Match test file names to their targets (`foo_test.py`, `Foo.spec.ts`, `mod_test.rs`).
+- Keep unit tests fast enough for CI; mark slow suites with conventional skips or flags.
+- Aim for about 80% coverage when tooling supports it and explain gaps in the PR.
 - Run the full test suite locally before requesting review.
 
 ## Commit & Pull Request Guidelines
-- Write commits in the narrated voice outlined in `.github/CONTRIBUTING.md`; lead with the why before the what.
-- Reference the driving issue in the first line when possible (`feat: align auth scopes (#123)`).
-- Keep PRs narrowly scoped; include screenshots or terminal captures when behaviour changes.
-- Confirm CI passes and note any required follow-ups or toggles under a "Next steps" heading in the PR body.
+- Follow the narrated voice from `.github/CONTRIBUTING.md`: lead with the why, then the what and next steps.
+- Reference the driving issue in commit subject lines when available (`feat: align auth scopes (#123)`).
+- Keep PRs focused; include screenshots or terminal captures when behaviour changes.
+- Ensure CI is green and document any toggles or follow-up tasks under "Next steps" in the PR body.
+
+## Architecture Decision Records (ADRs)
+- Snapshot significant architecture choices under `docs/adr/`; copy `template.md` to the next `000X-title.md` file before editing.
+- Write concise context, decision, and consequence sections; update the status from `Proposed` to `Accepted`, `Rejected`, or `Superseded` once merged.
+- Link supporting issues, diagrams, or PRs in the ADR and reference the record in your pull request narrative. Leave superseded ADRs in place with a note to the successor.
 
 ## Agent-Specific Notes
 - Automations and scripts assume repositories live under `~/GitHub/LacardLabs/<repo>`.
-- Prefer idempotent commands; call tooling with explicit paths so agents can re-run safely.
-- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers in sync.
+- Prefer idempotent commands and pass explicit paths so agents can re-run safely.
+- Surface surprises (unexpected files, failing hooks) in PR descriptions to keep reviewers aligned.

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -25,7 +25,7 @@
 ## Architecture Decision Records (ADRs)
 - Explain when your team expects a new ADR versus updating an existing one.
 - Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.). Call out that live ADRs stay at the root, superseded records move into `archive/`, and supporting diagrams belong in `assets/<adr-number>/` (README placeholders explain the directory expectations).
-- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable. Mention the starter files in `docs/adr/examples/` if you want agents to follow or delete them.
+- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable. Mention the starter files in `docs/adr/examples/0001-adopt-adr-process.md` and `docs/adr/examples/0002-adr-directory-structure.md` if you want agents to follow or delete them.
 
 ## Agent-Specific Notes
 - Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -22,6 +22,11 @@
 - Restate your team's expectations for commit messages, PR structure, and required artifacts (screenshots, logs, etc.).
 - Link to any additional docs (CONTRIBUTING, architecture notes) reviewers should read before approving.
 
+## Architecture Decision Records (ADRs)
+- Explain when your team expects a new ADR versus updating an existing one.
+- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.).
+- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable.
+
 ## Agent-Specific Notes
 - Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).
 - Flag common pitfalls, reset procedures, or environment constraints that agents should surface in PRs.

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -24,8 +24,8 @@
 
 ## Architecture Decision Records (ADRs)
 - Explain when your team expects a new ADR versus updating an existing one.
-- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.). Call out that live ADRs stay at the root, superseded records move into `archive/`, and supporting diagrams belong in `assets/<adr-number>/`.
-- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable. Mention the starter file in `docs/adr/examples/` if you want agents to follow or delete it.
+- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.). Call out that live ADRs stay at the root, superseded records move into `archive/`, and supporting diagrams belong in `assets/<adr-number>/` (README placeholders explain the directory expectations).
+- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable. Mention the starter files in `docs/adr/examples/` if you want agents to follow or delete them.
 
 ## Agent-Specific Notes
 - Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -24,8 +24,8 @@
 
 ## Architecture Decision Records (ADRs)
 - Explain when your team expects a new ADR versus updating an existing one.
-- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.).
-- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable.
+- Note the numbering scheme (`0001-short-title.md`), where to copy the template from, and which statuses you use (`Proposed`, `Accepted`, etc.). Call out that live ADRs stay at the root, superseded records move into `archive/`, and supporting diagrams belong in `assets/<adr-number>/`.
+- Tell contributors where to link ADRs (e.g., PR narrative, docs index) so the rationale remains discoverable. Mention the starter file in `docs/adr/examples/` if you want agents to follow or delete it.
 
 ## Agent-Specific Notes
 - Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).

--- a/AGENTS.template.md
+++ b/AGENTS.template.md
@@ -1,0 +1,27 @@
+# Repository Guidelines
+
+> Copy this file to `AGENTS.md` and tailor each section for your project. Keep explanations concise (200–400 words) and specific to your repo.
+
+## Project Structure & Module Organization
+- Summarize where core source, tests, and assets reside once your project scaffolding is in place.
+- Note any directories that downstream agents should avoid or clean up after bootstrapping.
+
+## Build, Test, and Development Commands
+- Document the commands contributors should run after cloning (include `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` if you keep the default path assumption).
+- List the canonical build, lint, and test commands, calling out any optional tooling like `make`.
+
+## Coding Style & Naming Conventions
+- Record formatting standards (indentation, casing, formatter tools) that apply to your stack.
+- Mention naming patterns for files, packages, and exported symbols so agents can create files confidently.
+
+## Testing Guidelines
+- Describe the testing frameworks in use and how to execute the suites locally.
+- Include coverage expectations, file naming conventions, and guidance for slow or optional tests.
+
+## Commit & Pull Request Guidelines
+- Restate your team's expectations for commit messages, PR structure, and required artifacts (screenshots, logs, etc.).
+- Link to any additional docs (CONTRIBUTING, architecture notes) reviewers should read before approving.
+
+## Agent-Specific Notes
+- Capture assumptions your automations make (e.g., repositories cloned under `~/GitHub/LacardLabs/<repo>`).
+- Flag common pitfalls, reset procedures, or environment constraints that agents should surface in PRs.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Lacard Labs Repository Template
 
-> ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
+> ⚙️ After bootstrapping with **Use this template**, create the repo on GitHub, then run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and `cd ~/GitHub/LacardLabs/<repo>` before editing. Update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
-This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo locally.
+This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo to `~/GitHub/LacardLabs/<repo>`.
 
 ## Setup checklist (delete when finished)
 
 - [ ] In **Settings → General**, update the repo description, confirm visibility, and assign the owning team.
+- [ ] Clone the repo locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and verify `pwd` resolves to that path.
 - [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
 - [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
 - [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don't need.
@@ -19,10 +20,10 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 ## How to use the template
 
 1. Click **Use this template** to create the new repository under the Lacard Labs org.
-2. Clone it locally before editing; all commands below assume you are inside the repo directory.
+2. Clone it locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` before editing; all commands below assume you are inside that directory.
 3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
 4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
-5. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
+5. Run `pwd` or `ls` to sanity-check that you are under `~/GitHub/LacardLabs/<repo>` before committing. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
 
 ## Included developer experience files
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is the starting point for new Lacard Labs projects. It stays int
 - [ ] Clone the repo locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and verify `pwd` resolves to that path.
 - [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
 - [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
-- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the sample ADR under `docs/adr/examples/` so they match how your project works. Keep the `docs/adr/archive/` and `docs/adr/assets/` directories if you expect to store superseded records or supporting diagrams later.
+- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the sample ADRs under `docs/adr/examples/` so they match how your project works. Keep the `docs/adr/archive/` and `docs/adr/assets/` directories (plus their README placeholders) if you expect to store superseded records or supporting diagrams later.
 - [ ] Confirm `main` branch protection (PR review, required CI check, squash-only merges, delete merged branches) matches org policy.
 - [ ] Push a quick "smoke" commit to verify the reusable CI passes end to end.
 - [ ] Remove this checklist (and `SETUP.md`) once everything above is complete.
@@ -31,14 +31,14 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 - `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
 - `Makefile` — optional `setup`, `lint`, and `test` convenience targets. Delete it if you prefer not to depend on `make` yet.
 - `.env.example` — placeholder for local-only environment variables.
-- `docs/adr/` — starter guide, template, and directory structure for Architecture Decision Records (live records at the root, archived decisions under `archive/`, supporting diagrams in `assets/<adr-number>/`).
+- `docs/adr/` — starter guide, template, and directory structure for Architecture Decision Records (live records at the root, archived decisions under `archive/`, supporting diagrams in `assets/<adr-number>/`, and example ADRs under `examples/`).
 
 ## Architecture Decision Records
 
 - Create a new ADR whenever you commit to a meaningful architectural choice (data store, deployment model, auth strategy, cross-service contracts).
 - Copy `docs/adr/template.md` to the next sequence number (e.g., `cp docs/adr/template.md docs/adr/0003-adopt-openapi.md`), update the front matter, and capture context, decision, and consequences.
 - Keep the status field accurate (`Proposed` → `Accepted`/`Rejected`/`Superseded`) and link to the tracking issue or PR in the decision section so readers can follow the history.
-- Store supporting diagrams or data under `docs/adr/assets/<adr-number>/` and move superseded records to `docs/adr/archive/` once they reference the successor.
+- Store supporting diagrams or data under `docs/adr/assets/<adr-number>/` (see the README in that directory for naming guidance) and move superseded records to `docs/adr/archive/` once they reference the successor.
 - Use `docs/adr/examples/0001-adopt-adr-process.md` as an onboarding reference, then delete the `examples/` directory when you have real ADRs in place.
 - Commit ADRs alongside the implementation change and mention the record in your PR under the "Develop" or "Docs" callout so reviewers see the rationale.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is the starting point for new Lacard Labs projects. It stays int
 - [ ] Clone the repo locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and verify `pwd` resolves to that path.
 - [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
 - [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
-- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don't need.
+- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the sample ADR under `docs/adr/examples/` so they match how your project works. Keep the `docs/adr/archive/` and `docs/adr/assets/` directories if you expect to store superseded records or supporting diagrams later.
 - [ ] Confirm `main` branch protection (PR review, required CI check, squash-only merges, delete merged branches) matches org policy.
 - [ ] Push a quick "smoke" commit to verify the reusable CI passes end to end.
 - [ ] Remove this checklist (and `SETUP.md`) once everything above is complete.
@@ -23,7 +23,7 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 2. Clone it locally with `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` before editing; all commands below assume you are inside that directory.
 3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
 4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
-5. Run `pwd` or `ls` to sanity-check that you are under `~/GitHub/LacardLabs/<repo>` before committing. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
+5. Run `pwd` or `ls` to sanity-check that you are under `~/GitHub/LacardLabs/<repo>` before committing. Remove unused scaffolding (`docs/adr/examples/`, unused Makefile targets, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
 
 ## Included developer experience files
 
@@ -31,13 +31,15 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 - `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
 - `Makefile` — optional `setup`, `lint`, and `test` convenience targets. Delete it if you prefer not to depend on `make` yet.
 - `.env.example` — placeholder for local-only environment variables.
-- `docs/adr/` — starter guide and template for Architecture Decision Records.
+- `docs/adr/` — starter guide, template, and directory structure for Architecture Decision Records (live records at the root, archived decisions under `archive/`, supporting diagrams in `assets/<adr-number>/`).
 
 ## Architecture Decision Records
 
 - Create a new ADR whenever you commit to a meaningful architectural choice (data store, deployment model, auth strategy, cross-service contracts).
 - Copy `docs/adr/template.md` to the next sequence number (e.g., `cp docs/adr/template.md docs/adr/0003-adopt-openapi.md`), update the front matter, and capture context, decision, and consequences.
 - Keep the status field accurate (`Proposed` → `Accepted`/`Rejected`/`Superseded`) and link to the tracking issue or PR in the decision section so readers can follow the history.
+- Store supporting diagrams or data under `docs/adr/assets/<adr-number>/` and move superseded records to `docs/adr/archive/` once they reference the successor.
+- Use `docs/adr/examples/0001-adopt-adr-process.md` as an onboarding reference, then delete the `examples/` directory when you have real ADRs in place.
 - Commit ADRs alongside the implementation change and mention the record in your PR under the "Develop" or "Docs" callout so reviewers see the rationale.
 
 ## Why ship `README.template.md` instead of auto-populating?

--- a/README.md
+++ b/README.md
@@ -1,32 +1,33 @@
 # Lacard Labs Repository Template
 
-> ⚙️ **Required action after cloning:** open `.github/workflows/ci.yml` and change the `language:` line to match your stack (`python`, `node`, `rust`, or `none`).
+> ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
 This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo.
 
 ## Setup checklist (delete when finished)
 
-- [ ] Rename the repo description and set visibility/owners in GitHub settings.
-- [ ] Update `.github/workflows/ci.yml` → `language: <stack>` so CI runs the right toolchain.
-- [ ] Copy `README.template.md` to `README.md`, rewrite it for this project, then delete the template file.
-- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don’t need.
-- [ ] Confirm branch protection on `main` (PR review, required CI check, squash-only, delete merged branches).
-- [ ] Run a smoke commit to verify the reusable CI passes.
+- [ ] In **Settings → General**, update the repo description, confirm visibility, and assign the owning team.
+- [ ] Edit `.github/workflows/ci.yml` and set `language: <stack>` so CI runs the right toolchain.
+- [ ] Copy `README.template.md` to `README.md`, personalize it for this project, then delete the template file.
+- [ ] Trim `.pre-commit-config.yaml`, `Makefile`, and other scaffolding you do or don't need.
+- [ ] Confirm `main` branch protection (PR review, required CI check, squash-only merges, delete merged branches) matches org policy.
+- [ ] Push a quick "smoke" commit to verify the reusable CI passes end to end.
 - [ ] Remove this checklist (and `SETUP.md`) once everything above is complete.
 
 See `SETUP.md` for the same list plus links and reminders that reviewers can follow.
 
 ## How to use the template
 
-1. Click **Use this template** and create a new repository.
-2. Walk through the checklist above so policy, CI, and docs are wired correctly.
-3. Run `pre-commit install` to enable local checks, and trim the hooks you do not need.
-4. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
+1. Click **Use this template** to create the new repository under the Lacard Labs org.
+2. Clone it locally before editing; all commands below assume you are inside the repo directory.
+3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
+4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
+5. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
 
 ## Included developer experience files
 
 - `.editorconfig` — enforces consistent whitespace across editors.
-- `.pre-commit-config.yaml` — lightweight whitespace and Ruff lint hook; extend as needed.
+- `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
 - `Makefile` — optional `setup`, `lint`, and `test` convenience targets that autodetect common stacks.
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.
 
+## Architecture Decision Records
+
+- Create a new ADR whenever you commit to a meaningful architectural choice (data store, deployment model, auth strategy, cross-service contracts).
+- Copy `docs/adr/template.md` to the next sequence number (e.g., `cp docs/adr/template.md docs/adr/0003-adopt-openapi.md`), update the front matter, and capture context, decision, and consequences.
+- Keep the status field accurate (`Proposed` → `Accepted`/`Rejected`/`Superseded`) and link to the tracking issue or PR in the decision section so readers can follow the history.
+- Commit ADRs alongside the implementation change and mention the record in your PR under the "Develop" or "Docs" callout so reviewers see the rationale.
+
 ## Why ship `README.template.md` instead of auto-populating?
 
 The template keeps the default `README.md` focused on setup guardrails, while `README.template.md` is a narrative scaffold for the actual project. Copying it forces each new repo to:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚙️ After bootstrapping with **Use this template**, clone the repo (`git clone git@github.com:LacardLabs/<repo>.git && cd <repo>`) and update `.github/workflows/ci.yml` so the `language:` input matches your stack before the first pull request.
 
-This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo.
+This repository is the starting point for new Lacard Labs projects. It stays intentionally thin—policies, automation, and community health live in the `.github` control-plane repo. All directions below assume you've already cloned the repo locally.
 
 ## Setup checklist (delete when finished)
 
@@ -22,13 +22,13 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 2. Clone it locally before editing; all commands below assume you are inside the repo directory.
 3. Walk through the setup checklist so policy, CI, and docs are wired correctly.
 4. Run `pre-commit install` to register the repo's hooks locally. The defaults auto-fix whitespace issues and run Ruff linting before every commit so broken formatting never reaches CI. Tweak the hook list if your stack needs more (or fewer) checks.
-5. Remove unused scaffolding (Make targets, ADR template, etc.) to keep the repo focused.
+5. Remove unused scaffolding (ADR template, etc.) to keep the repo focused. We do not assume `make` usage by default—feel free to delete the Makefile if your project won't adopt it soon.
 
 ## Included developer experience files
 
 - `.editorconfig` — enforces consistent whitespace across editors.
 - `.pre-commit-config.yaml` — configures the whitespace fixer and Ruff lint hooks that run via `pre-commit`.
-- `Makefile` — optional `setup`, `lint`, and `test` convenience targets that autodetect common stacks.
+- `Makefile` — optional `setup`, `lint`, and `test` convenience targets. Delete it if you prefer not to depend on `make` yet.
 - `.env.example` — placeholder for local-only environment variables.
 - `docs/adr/` — starter guide and template for Architecture Decision Records.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See `SETUP.md` for the same list plus links and reminders that reviewers can fol
 - Copy `docs/adr/template.md` to the next sequence number (e.g., `cp docs/adr/template.md docs/adr/0003-adopt-openapi.md`), update the front matter, and capture context, decision, and consequences.
 - Keep the status field accurate (`Proposed` → `Accepted`/`Rejected`/`Superseded`) and link to the tracking issue or PR in the decision section so readers can follow the history.
 - Store supporting diagrams or data under `docs/adr/assets/<adr-number>/` (see the README in that directory for naming guidance) and move superseded records to `docs/adr/archive/` once they reference the successor.
-- Use `docs/adr/examples/0001-adopt-adr-process.md` as an onboarding reference, then delete the `examples/` directory when you have real ADRs in place.
+- Use `docs/adr/examples/0001-adopt-adr-process.md` and `docs/adr/examples/0002-adr-directory-structure.md` as onboarding references, then delete the `examples/` directory when you have real ADRs in place.
 - Commit ADRs alongside the implementation change and mention the record in your PR under the "Develop" or "Docs" callout so reviewers see the rationale.
 
 ## Why ship `README.template.md` instead of auto-populating?

--- a/README.template.md
+++ b/README.template.md
@@ -30,7 +30,7 @@ jobs:
 
 ## Decision Records
 
-Document significant technical choices under `docs/adr/`. Start each ADR from `docs/adr/template.md` and track them in `docs/adr/README.md`.
+Track significant technical choices under `docs/adr/`. Copy `template.md` to the next `000X-short-title.md`, keep live ADRs at the root, move superseded records into `archive/`, and store diagrams or data in `assets/<adr-number>/`. Delete the starter entry in `docs/adr/examples/` once this project has its first real ADR.
 
 ## Security
 

--- a/README.template.md
+++ b/README.template.md
@@ -54,7 +54,7 @@ jobs:
 
 ## Decision Records
 
-Track significant technical choices under `docs/adr/`. Copy `template.md` to the next `000X-short-title.md`, keep live ADRs at the root, move superseded records into `archive/`, and store diagrams or data in `assets/<adr-number>/`. Delete the starter entry in `docs/adr/examples/` once this project has its first real ADR.
+Track significant technical choices under `docs/adr/`. Copy `template.md` to the next `000X-short-title.md`, keep live ADRs at the root, move superseded records into `archive/`, and store diagrams or data in `assets/<adr-number>/`. The `archive/` and `assets/` directories include README placeholders that describe how to organize their contents. Delete the starter entries in `docs/adr/examples/` once this project has its first real ADR.
 
 ## Security
 

--- a/README.template.md
+++ b/README.template.md
@@ -54,7 +54,7 @@ jobs:
 
 ## Decision Records
 
-Track significant technical choices under `docs/adr/`. Copy `template.md` to the next `000X-short-title.md`, keep live ADRs at the root, move superseded records into `archive/`, and store diagrams or data in `assets/<adr-number>/`. The `archive/` and `assets/` directories include README placeholders that describe how to organize their contents. Delete the starter entries in `docs/adr/examples/` once this project has its first real ADR.
+Track significant technical choices under `docs/adr/`. Copy `template.md` to the next `000X-short-title.md`, keep live ADRs at the root, move superseded records into `archive/`, and store diagrams or data in `assets/<adr-number>/`. The `archive/` and `assets/` directories include README placeholders that describe how to organize their contents. Reference the sample ADRs in `docs/adr/examples/0001-adopt-adr-process.md` and `docs/adr/examples/0002-adr-directory-structure.md`, then delete the `examples/` directory once this project has its first real record.
 
 ## Security
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ This checklist duplicates the quick list in `README.md`, but keeps more detail f
 - [ ] **Clone path** – Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and confirm `pwd` resolves to `~/GitHub/LacardLabs/<repo>` before making local edits.
 - [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
 - [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
-- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the ADR starter content so they reflect actual usage. Keep `docs/adr/archive/` and `docs/adr/assets/` (including the README placeholders) for future records, but delete `docs/adr/examples/` once you have a real ADR. Remove the `Makefile` if your service won't adopt `make` yet.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the ADR starter content so they reflect actual usage. Keep `docs/adr/archive/` and `docs/adr/assets/` (including the README placeholders) for future records, but delete `docs/adr/examples/`—which ships sample records `0001-adopt-adr-process.md` and `0002-adr-directory-structure.md`—once you have a real ADR. Remove the `Makefile` if your service won't adopt `make` yet.
 - [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
 - [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
 - [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ This checklist duplicates the quick list in `README.md`, but keeps more detail f
 - [ ] **Clone path** – Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and confirm `pwd` resolves to `~/GitHub/LacardLabs/<repo>` before making local edits.
 - [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
 - [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
-- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage. Remove the `Makefile` if your service won't adopt `make` yet.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the ADR starter content so they reflect actual usage. Keep `docs/adr/archive/` and `docs/adr/assets/` for future records, but delete `docs/adr/examples/` once you have a real ADR. Remove the `Makefile` if your service won't adopt `make` yet.
 - [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
 - [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
 - [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ This checklist duplicates the quick list in `README.md`, but keeps more detail f
 - [ ] **Clone path** – Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and confirm `pwd` resolves to `~/GitHub/LacardLabs/<repo>` before making local edits.
 - [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
 - [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
-- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the ADR starter content so they reflect actual usage. Keep `docs/adr/archive/` and `docs/adr/assets/` for future records, but delete `docs/adr/examples/` once you have a real ADR. Remove the `Makefile` if your service won't adopt `make` yet.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and the ADR starter content so they reflect actual usage. Keep `docs/adr/archive/` and `docs/adr/assets/` (including the README placeholders) for future records, but delete `docs/adr/examples/` once you have a real ADR. Remove the `Makefile` if your service won't adopt `make` yet.
 - [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
 - [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
 - [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,11 +1,12 @@
 # Repository Setup Checklist
 
-This checklist duplicates the quick list in `README.md`, but keeps more detail for reviewers or automation to follow. Delete this file once every item is complete.
+This checklist duplicates the quick list in `README.md`, but keeps more detail for reviewers or automation to follow. Delete this file once every item is complete. All steps assume the repository was created from this template on GitHub and cloned locally under `~/GitHub/LacardLabs/<repo>`.
 
 - [ ] **Name & visibility** – Update the repository description, topics, and visibility in GitHub settings.
+- [ ] **Clone path** – Run `gh repo clone LacardLabs/<repo> ~/GitHub/LacardLabs/<repo>` and confirm `pwd` resolves to `~/GitHub/LacardLabs/<repo>` before making local edits.
 - [ ] **CI language** – Edit `.github/workflows/ci.yml` and set `language: python|node|rust|none` to match the primary stack.
 - [ ] **README handoff** – Copy `README.template.md` to `README.md`, tailor it to the project, then remove the template file.
-- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage.
+- [ ] **Scaffold trim** – Prune or extend `.pre-commit-config.yaml`, `Makefile`, `.env.example`, and ADR docs so they reflect actual usage. Remove the `Makefile` if your service won't adopt `make` yet.
 - [ ] **Branch protection** – Ensure `main` requires PR review, the reusable CI status check, squash-only merges, linear history, and deletes branches on merge.
 - [ ] **Smoke test** – Push a throwaway change to confirm the reusable CI runs cleanly (CodeQL/SBOM toggles as needed).
 - [ ] **Final cleanup** – Delete this `SETUP.md` file and the checklist section in `README.md` once everything above is done.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,24 @@ ADRs capture the narrative behind major technical choices so future contributors
 - Replace a core dependency (database, queue, framework) or change a critical design constraint.
 - Approve an experiment that alters reliability, scalability, or security characteristics.
 
+## Suggested directory structure
+
+The repository template keeps ADRs alongside supporting material so everything ships together:
+
+```text
+docs/
+└── adr/
+    ├── README.md               # Usage guide and index
+    ├── template.md             # Copy for new ADRs
+    ├── assets/                 # Optional diagrams or data per ADR (e.g., assets/0002/)
+    ├── archive/                # Superseded ADRs moved here after linking replacements
+    ├── examples/               # Sample ADRs to reference; delete once the team has real records
+    ├── 0001-introduce-adr-process.md
+    └── 0002-choose-ci-provider.md
+```
+
+Keep live ADRs at the top level for quick discovery. Move superseded records into `archive/` once they link to the replacement decision, and store heavy assets under `assets/<adr-number>/` so Markdown files stay lean. The `examples/` directory contains sample content you can delete once the team adds its first real ADR.
+
 ## How to create an ADR
 
 1. Identify the next sequence number in this directory (`ls docs/adr`); format it as four digits (`0001-...`).
@@ -20,5 +38,9 @@ ADRs capture the narrative behind major technical choices so future contributors
 - When a decision is replaced, leave the original ADR intact and add a "Superseded by" note pointing to the new record.
 - Keep language plain and action-oriented; these documents should answer "what should we keep doing or avoid?" for future teammates.
 - Link the ADR in your pull request under the Docs/Develop section so downstream readers can find it quickly.
+
+## Example ADR
+
+Use `docs/adr/examples/0001-adopt-adr-process.md` as a reference if you are unsure how much detail to capture or how to handle links and consequences. Delete the sample once the team creates its first real ADR.
 
 For additional background, see [Documenting architecture decisions](https://adr.github.io/).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,9 +17,9 @@ docs/
     ├── template.md             # Copy for new ADRs
     ├── assets/                 # Placeholder README and numbered folders for diagrams (e.g., assets/0002/)
     ├── archive/                # Superseded ADRs moved here after linking replacements (README explains expectations)
-    ├── examples/               # Sample ADRs to reference; delete once the team has real records
-    ├── 0001-introduce-adr-process.md
-    └── 0002-choose-ci-provider.md
+    └── examples/               # Sample ADRs to reference; delete once the team has real records
+        ├── 0001-adopt-adr-process.md
+        └── 0002-adr-directory-structure.md
 ```
 
 Keep live ADRs at the top level for quick discovery. Move superseded records into `archive/` once they link to the replacement decision, and store heavy assets under `assets/<adr-number>/` so Markdown files stay lean. The `archive/` and `assets/` directories include README placeholders that explain how to structure their contents. The `examples/` directory contains sample content you can delete once the team adds its first real ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,7 +1,24 @@
 # Architecture Decision Records
 
-1. Copy `template.md` and rename it with the next sequence number, e.g., `0001-use-postgres.md`.
-2. Record the date, context, decision, and consequences succinctly.
-3. Commit ADRs alongside the change they describe so the history stays in sync.
+ADRs capture the narrative behind major technical choices so future contributors understand the why, not just the code diff. Use them when you:
 
-Keep ADRs lightweight—capture the why and the tradeoffs, not every implementation detail.
+- Introduce a new system boundary, integration, or deployment strategy.
+- Replace a core dependency (database, queue, framework) or change a critical design constraint.
+- Approve an experiment that alters reliability, scalability, or security characteristics.
+
+## How to create an ADR
+
+1. Identify the next sequence number in this directory (`ls docs/adr`); format it as four digits (`0001-...`).
+2. Copy the template: `cp docs/adr/template.md docs/adr/000X-short-title.md` and update the title to match the change.
+3. Fill out **Context**, **Decision**, and **Consequences** in 2–4 tight paragraphs each. Reference linked issues, diagrams, or RFCs inline.
+4. Set `Status` to `Proposed` while the change is under review. Update it to `Accepted`, `Rejected`, or `Superseded` once the PR lands.
+5. Commit the ADR alongside the implementation code so reviewers can evaluate intent and execution together.
+
+## Maintaining ADRs
+
+- Add a short summary or index entry to this README if the list grows beyond what `ls` can convey.
+- When a decision is replaced, leave the original ADR intact and add a "Superseded by" note pointing to the new record.
+- Keep language plain and action-oriented; these documents should answer "what should we keep doing or avoid?" for future teammates.
+- Link the ADR in your pull request under the Docs/Develop section so downstream readers can find it quickly.
+
+For additional background, see [Documenting architecture decisions](https://adr.github.io/).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,14 +15,14 @@ docs/
 └── adr/
     ├── README.md               # Usage guide and index
     ├── template.md             # Copy for new ADRs
-    ├── assets/                 # Optional diagrams or data per ADR (e.g., assets/0002/)
-    ├── archive/                # Superseded ADRs moved here after linking replacements
+    ├── assets/                 # Placeholder README and numbered folders for diagrams (e.g., assets/0002/)
+    ├── archive/                # Superseded ADRs moved here after linking replacements (README explains expectations)
     ├── examples/               # Sample ADRs to reference; delete once the team has real records
     ├── 0001-introduce-adr-process.md
     └── 0002-choose-ci-provider.md
 ```
 
-Keep live ADRs at the top level for quick discovery. Move superseded records into `archive/` once they link to the replacement decision, and store heavy assets under `assets/<adr-number>/` so Markdown files stay lean. The `examples/` directory contains sample content you can delete once the team adds its first real ADR.
+Keep live ADRs at the top level for quick discovery. Move superseded records into `archive/` once they link to the replacement decision, and store heavy assets under `assets/<adr-number>/` so Markdown files stay lean. The `archive/` and `assets/` directories include README placeholders that explain how to structure their contents. The `examples/` directory contains sample content you can delete once the team adds its first real ADR.
 
 ## How to create an ADR
 
@@ -41,6 +41,6 @@ Keep live ADRs at the top level for quick discovery. Move superseded records int
 
 ## Example ADR
 
-Use `docs/adr/examples/0001-adopt-adr-process.md` as a reference if you are unsure how much detail to capture or how to handle links and consequences. Delete the sample once the team creates its first real ADR.
+Use `docs/adr/examples/0001-adopt-adr-process.md` and `docs/adr/examples/0002-adr-directory-structure.md` as references if you are unsure how much detail to capture or how to handle links and consequences. Delete the samples once the team creates its first real ADR.
 
 For additional background, see [Documenting architecture decisions](https://adr.github.io/).

--- a/docs/adr/archive/README.md
+++ b/docs/adr/archive/README.md
@@ -1,0 +1,4 @@
+# ADR Archive
+
+Move superseded architecture decision records into this directory after linking them to the replacement.
+Keep the filenames and numbering intact so historical context remains traceable.

--- a/docs/adr/assets/README.md
+++ b/docs/adr/assets/README.md
@@ -1,0 +1,4 @@
+# ADR Assets
+
+Store supporting diagrams, data exports, or other large artifacts for each ADR in a numbered subdirectory.
+For example, `assets/0003/` should contain the material referenced by `docs/adr/0003-*.md`.

--- a/docs/adr/examples/0001-adopt-adr-process.md
+++ b/docs/adr/examples/0001-adopt-adr-process.md
@@ -1,8 +1,8 @@
 # Adopt ADR Process
 
-- Status: Accepted
-- Date: 2024-04-15
-- Tags: process, documentation
+- **Status:** Accepted
+- **Date:** 2024-04-15
+- **Tags:** process, documentation
 
 ## Context
 

--- a/docs/adr/examples/0001-adopt-adr-process.md
+++ b/docs/adr/examples/0001-adopt-adr-process.md
@@ -1,0 +1,28 @@
+# Adopt ADR Process
+
+- Status: Accepted
+- Date: 2024-04-15
+- Tags: process, documentation
+
+## Context
+
+The engineering team is onboarding more contributors and making architectural changes without a shared paper trail. Decisions that shape CI/CD, production topology, and dependency lifecycle are currently scattered across pull requests and chat logs, making it difficult for new teammates to understand why certain constraints exist.
+
+Our product roadmap includes several foundational initiatives—introducing a service mesh, reworking our data pipeline, and tightening security boundaries—that will benefit from traceable rationale. We need a lightweight, version-controlled approach that fits within the existing developer workflow and supports cross-team review.
+
+## Decision
+
+We introduce Architecture Decision Records (ADRs) stored under `docs/adr` inside the repository. Each ADR will use a zero-padded numeric prefix (e.g., `0001-...`) followed by a short, kebab-case summary. Authors copy `docs/adr/template.md`, fill in Context, Decision, Consequences, and Links, then submit the ADR alongside the implementation change for review.
+
+ADRs start in the `Proposed` state and transition to `Accepted`, `Rejected`, or `Superseded` as the work progresses. Superseded ADRs remain in place for historical context and reference the replacement record. Supporting assets such as diagrams live in `docs/adr/assets/<adr-number>/` to keep the main record focused and readable.
+
+## Consequences
+
+- Improved onboarding because the why behind core constraints is discoverable in one location.
+- Slightly higher overhead for major changes; we mitigate this by keeping the template lightweight and enforcing it only for high-impact decisions.
+- Clearer audit trail when revisiting past decisions or communicating rationale to stakeholders.
+
+## Links
+
+- docs/adr/template.md
+- https://adr.github.io/

--- a/docs/adr/examples/0001-adopt-adr-process.md
+++ b/docs/adr/examples/0001-adopt-adr-process.md
@@ -24,5 +24,5 @@ ADRs start in the `Proposed` state and transition to `Accepted`, `Rejected`, or 
 
 ## Links
 
-- docs/adr/template.md
-- https://adr.github.io/
+- [ADR template](../template.md)
+- [Documenting architecture decisions](https://adr.github.io/)

--- a/docs/adr/examples/0002-adr-directory-structure.md
+++ b/docs/adr/examples/0002-adr-directory-structure.md
@@ -1,0 +1,25 @@
+# 0002: Align ADR directory structure
+
+- **Status:** Accepted
+- **Deciders:** Template Maintainers
+- **Date:** 2025-01-15
+
+## Context
+
+New repositories bootstrapped from the template need a predictable way to store active, superseded, and supporting ADR material.
+Earlier projects mixed sample ADRs with live records, which made it hard to see which decisions were current or where diagrams lived.
+
+## Decision
+
+Adopt a canonical layout under `docs/adr/`:
+
+- Keep active ADR Markdown files at the root of the directory for quick discovery.
+- Store replaced decisions in `docs/adr/archive/` without renumbering them so historical context is preserved.
+- Capture large diagrams or exports in `docs/adr/assets/<adr-number>/` and reference them from the ADR body.
+- Ship sample ADRs in `docs/adr/examples/` that new teams can reference and then delete once they publish their own records.
+
+## Consequences
+
+- Contributors always know where to add new records and where to look for related assets.
+- Superseded decisions remain available without cluttering the active ADR list.
+- The template can safely include example content without confusing it for production decisions.

--- a/docs/adr/examples/0002-adr-directory-structure.md
+++ b/docs/adr/examples/0002-adr-directory-structure.md
@@ -26,6 +26,6 @@ Adopt a canonical layout under `docs/adr/`:
 
 ## Links
 
-- docs/adr/template.md
-- docs/adr/archive/README.md
-- docs/adr/assets/README.md
+- [ADR template](../template.md)
+- [Archive guidance](../archive/README.md)
+- [Assets guidance](../assets/README.md)

--- a/docs/adr/examples/0002-adr-directory-structure.md
+++ b/docs/adr/examples/0002-adr-directory-structure.md
@@ -23,3 +23,9 @@ Adopt a canonical layout under `docs/adr/`:
 - Contributors always know where to add new records and where to look for related assets.
 - Superseded decisions remain available without cluttering the active ADR list.
 - The template can safely include example content without confusing it for production decisions.
+
+## Links
+
+- docs/adr/template.md
+- docs/adr/archive/README.md
+- docs/adr/assets/README.md

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,7 +1,8 @@
 # ADR Title
 
-- Status: Proposed
+- Status: Proposed (Accepted | Rejected | Superseded)
 - Date: YYYY-MM-DD
+- Tags: optional-keywords
 
 ## Context
 
@@ -14,3 +15,7 @@ Explain the choice that was made and the rationale.
 ## Consequences
 
 List the positive and negative outcomes, plus follow-up work if any.
+
+## Links
+
+Reference related issues, pull requests, diagrams, or external docs that informed the decision.


### PR DESCRIPTION
## Summary
- add usage guidance for the ADR directory structure across README, SETUP, and docs
- seed sample ADR plus archive/assets placeholders for future records
- update contributor and agent templates to reference the new examples and storage pattern

## Testing
- not run (docs-only)
